### PR TITLE
Move from onHook to event subscribing.

### DIFF
--- a/RoRecount.cs
+++ b/RoRecount.cs
@@ -20,19 +20,17 @@ namespace RiskOfRecount {
             TrackingDefs.Add(new TrackingDef("Total Healing", typeof(TrackingStatTotalHealing)));
             TrackingDefs.Add(new TrackingDef("Current DPS", typeof(TrackingStatCurrentDPS), true));
             TrackingDefs.Add(new TrackingDef("Peak DPS", typeof(TrackingStatPeakDPS)));
-
-            On.RoR2.HealthComponent.Heal += (orig, self, amount, procChainMask, nonRegen) => {
-                if (self.body && self.body.master && self.body.master.playerCharacterMasterController) {
-                    PlayerCharacterMasterController player = self.body.master.playerCharacterMasterController;
-                    if (player) {
-                        if (Math.Round(self.health + amount) <= self.body.maxHealth) {
-                            ui.LogEvent(player, "heal", amount);
-                        }
+            
+            HealthComponent.onCharacterHealServer += (healthComponent, amount) => {
+                var body = healthComponent.body;
+                if (body.isPlayerControlled && body.master) {
+                    masterController = body.master.playerCharacterMasterController;
+                    if(masterController) {
+                        ui.LogEvent(player, "heal", amount);
                     }
                 }
+            }
 
-                return orig(self, amount, procChainMask, nonRegen);
-            };
             On.RoR2.GlobalEventManager.OnHitEnemy += (orig, self, info, victim) => {
                 orig(self, info, victim);
 


### PR DESCRIPTION
By simplifiyng logic, errors can be avoided more easily.
However, this means this is run only when the display is on a host. I do not know how that would work with networking.
Or how that works with syncing to clients as I have not looked very well in how this mod works.